### PR TITLE
Set height to 100vh

### DIFF
--- a/core-header-panel.css
+++ b/core-header-panel.css
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host {
   display: block;
   position: relative;
+  height: 100vh;
 }
 
 #outerContainer {

--- a/core-header-panel.html
+++ b/core-header-panel.html
@@ -8,18 +8,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <!--
-`core-header-panel` contains a header section and a content panel section. Special
+`core-header-panel` contains a header section and a content panel section.
+
+By default, `core-header-panel` will set its height to fill the viewport. __To prevent double scroll bars, you should remove any margin from the body element.__ You can do this either with CSS, or by using the [fullbleed attribute](http://www.polymer-project.org/docs/polymer/layout-attrs.html#full-bleed-ltbody).
+
+    <body fullbleed>
+      <core-header-panel>
+        <core-toolbar>
+          <div>Hello World!</div>
+        </core-toolbar>
+        <div>Content goes here...</div>
+      </core-header-panel>
+    </body>
+
+ Special
 support is provided for scrolling modes when one uses a core-toolbar or equivalent
-for the header section.
+for the header section. The default behavior will create a sticky header.
 
 Example:
-
+    
     <core-header-panel>
       <core-toolbar>Header</core-toolbar>
       <div>Content goes here...</div>
     </core-header-panel>
 
-If you want to use other than `core-toolbar` for the header, add 
+Use `mode` to control the header and scrolling behavior.
+
+Example:
+    
+    <core-header-panel mode="scroll">
+      <core-toolbar>Header</core-toolbar>
+      <div>Content goes here...</div>
+    </core-header-panel>
+
+If you want to use something other than a `core-toolbar` for the header, add a
 `core-header` class to that element.
 
 Example:
@@ -28,8 +50,6 @@ Example:
       <div class="core-header">Header</div>
       <div>Content goes here...</div>
     </core-header-panel>
-
-Use `mode` to control the header and scrolling behavior.
 
 @group Polymer Core Elements
 @element core-header-panel


### PR DESCRIPTION
I've heard from a number of users that `core-header-panel` is confusing to use because you have to set it to fill the viewport somehow. Typically that's done by setting the html and body height to 100% and setting core-header-panel to have a height of 100%.

Setting a default of 100vh lets the user get up and running with `core-header-panel` immediately, the only gotcha is they have to remove margin from the body or it will create double scrollbars. I added a comment to the docs which points them to the [fullbleed attribute](http://www.polymer-project.org/docs/polymer/layout-attrs.html#full-bleed-ltbody).

cc @arthurevans
