### PR TITLE
config may not be set

### DIFF
--- a/core-header-panel.html
+++ b/core-header-panel.html
@@ -92,7 +92,7 @@ Use `mode` to control the header and scrolling behavior.
 </template>
 <script>
 
-  Polymer('core-header-panel', {
+  Polymer({
 
     /**
      * Fired when the content has been scrolled.  `event.detail.target` returns
@@ -225,7 +225,7 @@ Use `mode` to control the header and scrolling behavior.
           header.classList.toggle('animate', configs.tallMode[this.mode]);
         }
       }
-      if (configs.outerScroll[this.mode] || configs.outerScroll[old]) {
+      if (configs && (configs.outerScroll[this.mode] || configs.outerScroll[old])) {
         this.removeListener(old);
         this.addListener();
       }


### PR DESCRIPTION
This fixes an error I was seeing in core-component-page where core-header-panel gets the distributed nodes, expects a toolbar, but https://github.com/Polymer/core-doc-viewer/blob/master/elements/core-doc-page.html#L33 has been commented out.
